### PR TITLE
Renaming the "tests_tmt_ref" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ API key to the Testing Farm should be stored in your organization's secrets to s
 |-----------------------------|--------------------------------------------------------|-------------------------------|
 | `api_key`                   | A testing farm API key.                                | empty, **required from user** |
 | `tmt_repository`            | An url to tmt repository                               | empty, **required from user** |
+| `tmt_branch`                | A tmt tests branch which will be used for tests        | master                        |
 | `test_fmf_plan`             | A fmf plan which will be selected from tmt repository. | all                           |
-| `tests_tmt_ref`             | A tmt tests branch which will be used for tests        | master                        |
 | `compose`                   | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes)| Fedora |
 | `create_issue_comment`      | If GitHub action will create a github issue comment.   | false                         |
 | `pull_request_status_name`  | GitHub pull request status name                        | Fedora                        |

--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,13 @@ inputs:
   tmt_repository:
     description: 'An url to tmt repository'
     required: true
+  tmt_branch:
+    description: 'A branch of tmt repository which will be used for tests'
+    required: false
+    default: 'master'
   test_fmf_plan:
     required: false
     description: 'A fmf plan which will be selected. By default all plans are selected.'
-  tests_tmt_ref:
-    description: 'A tmt tests branch which will be used for tests'
-    required: false
-    default: 'master'
   compose:
     description: 'A compose for tests'
     default: 'Fedora'
@@ -92,8 +92,8 @@ runs:
           "api_key": "${{ inputs.api_key }}",
           "test": { "fmf": {
               "url": "${{ inputs.tmt_repository }}",
-              "ref": "${{ inputs.tmt_ref }}",
-              "name": "{{ inputs.tests_tmt_ref }}",
+              "ref": "${{ inputs.tmt_branch }}",
+              "name": "{{ inputs.test_fmf_plan }}",
             }
           },
           "environments": [{


### PR DESCRIPTION
This is just a suggestion, or maybe a proposition for further "brainstorming".

We should be cautious with the public API of this GitHub action, as it would be hard to rename the user-defined variables when the action will be used more. 

We should also double-check all other inputs, not only the test_tmt_ref, if they are really needed, and if their naming is suitable.

@phracek, @pkubatrh please take a look.