### PR TITLE
We should use proper name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
           ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
           
       - name: Schedule test on Testing Farm 
-        uses: action/testing-farm-action@v1
+        uses: actions/schedule-tests-on-testing-farm@v1
         with:
           api_key: ${{ secrets.TF_API_KEY }}
           tmt_repository: https://github.com/sclorg/sclorg-testing-farm


### PR DESCRIPTION
Tha proper calling is over `actions/schedule-tests-on-testing-farm` see here: 
https://github.com/marketplace/actions/schedule-tests-on-testing-farm