### PR TITLE
Add support for tmt.context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,23 @@ API key to the Testing Farm should be stored in your organization's secrets to s
 
 ## Action Inputs
 
-| Input Name                   | Description                                                                                   | Default value                 |
-|------------------------------|-----------------------------------------------------------------------------------------------|-------------------------------|
-| `api_key`                    | A testing farm API key.                                                                       | empty, **required from user** |
-| `tmt_repository`             | An url to tmt repository                                                                      | empty, **required from user** |
-| `test_fmf_plan`              | A fmf plan which will be selected from tmt repository.                                        | all                           |
-| `tests_tmt_ref`              | A tmt tests branch which will be used for tests                                               | master                        |
-| `compose`                    | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes) | Fedora                        |
-| `create_issue_comment`       | If GitHub action will create a github issue comment.                                          | false                         |
-| `pull_request_status_name`   | GitHub pull request status name                                                               | Fedora                        |
-| `arch`                       | Define an architecture for testing environment                                                | x86_64                        |
-| `env_vars`                   | Environment variables for test env, separated by ;                                            | empty                         |
-| `env_secrets`                | Environment secrets for test env, separated by ;                                              | empty                         |
-| `copr`                       | Copr name to use for the artifacts                                                            | epel-7-x86_64                 |
-| `test_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                         | empty                         |
-| `debug`                      | Print debug logs when working with testing farm                                               | true                          |
-| `update_pull_request_status` | Action will update pull request status. Default: true                                         | true                          |
+| Input Name                   | Description                                                                                                                       | Default value                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `api_key`                    | A testing farm API key.                                                                                                           | empty, **required from user** |
+| `tmt_repository`             | An url to tmt repository                                                                                                          | empty, **required from user** |
+| `test_fmf_plan`              | A fmf plan which will be selected from tmt repository.                                                                            | all                           |
+| `tests_tmt_ref`              | A tmt tests branch which will be used for tests                                                                                   | master                        |
+| `compose`                    | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes)                                     | Fedora                        |
+| `create_issue_comment`       | If GitHub action will create a github issue comment.                                                                              | false                         |
+| `pull_request_status_name`   | GitHub pull request status name                                                                                                   | Fedora                        |
+| `arch`                       | Define an architecture for testing environment                                                                                    | x86_64                        |
+| `env_vars`                   | Environment variables for test env, separated by ;                                                                                | empty                         |
+| `env_secrets`                | Environment secrets for test env, separated by ;                                                                                  | empty                         |
+| `copr`                       | Copr name to use for the artifacts                                                                                                | epel-7-x86_64                 |
+| `test_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
+| `debug`                      | Print debug logs when working with testing farm                                                                                   | true                          |
+| `update_pull_request_status` | Action will update pull request status. Default: true                                                                             | true                          |
+| `tmt_context`                | A mapping of tmt context variable [tmt-context](https://tmt.readthedocs.io/en/latest/spec/context.html), variables separated by ; | empty                         |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: '"fedora-copr-build" artifacts for testing environment. Separated by ;'
     required: false
     default: ''
+  tmt_context:
+    description: 'A value of tmt.context variable https://tmt.readthedocs.io/en/latest/spec/context.html, variables separated by ;'
+    required: false
+    default: ''
 outputs:
   request_id:
     description: 'An ID of a scheduled testing farm request'
@@ -102,6 +106,12 @@ runs:
         python -c 'import json;print(json.dumps(([{"type": "fedora-copr-build", "id": "{}:${{ inputs.copr }}".format(copr_id)} for copr_id in "${{ inputs.env_artifacts }}".split(";")])))' > artifacts
         echo "::set-output name=TMT_ENV_ARTIFACTS::$(cat env_artifacts)"
 
+    - name: Generate tmt context
+      id: generate_tmt_context
+      run: |
+        python -c 'import json; print({} if not "${{ inputs.tmt_context }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inputs.tmt_context }}".split(";")]}))' > tmt_context
+        echo "::set-output name=TMT_CONTEXT::$(cat tmt_context)"
+
     - name: Schedule a test on Testing Farm
       id: sched_test
       run: |
@@ -121,7 +131,10 @@ runs:
             },
             "variables": "${{ steps.generate_tmt_vars.outputs.TMT_ENV_VARS }}",
             "secrets": "${{ steps.generate_tmt_secrets.outputs.TMT_ENV_SECRETS }}",
-            "artifacts: "${{ steps.generate_tmt_artifacts.outputs.TMT_ENV_ARTIFACTS }}"
+            "artifacts: "${{ steps.generate_tmt_artifacts.outputs.TMT_ENV_ARTIFACTS }}",
+            "tmt": {
+              "context": ${{ steps.generate_tmt_context.outputs.TMT_CONTEXT }}
+            }
           }]
         }
         EOF


### PR DESCRIPTION
This pull request adds support for `tmt.context`.

This is the last piece of issue #16 .

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>