### PR TITLE
Streamline action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,62 @@
 # testing-farm-as-github-action
 
-Testing Farm as GitHub Action is a GitHub Action for executing tests on the Testing Farm infrastructure.
+Testing Farm as GitHub Action is a GitHub Action for executing tests on the [Testing Farm Service](https://docs.testing-farm.io).
 
-The tests to run are to be described with a [`fmf` plan](https://tmt.readthedocs.io/en/latest/spec.html) by the user of this GitHub Action.
+The tests to run are to be described with a [`tmt` plan](https://tmt.readthedocs.io/en/latest/spec.html) by the user of this GitHub Action.
 Pull Request status is automatically updated after the tests are executed,
 if this option is enabled with the `update_pull_request_status` user-defined input variable.
-
 
 Before calling this GitHub Action, you must first clone your project,
 e.g., with the [Checkout V2](https://github.com/actions/checkout) GitHub Action.
 
-The Action uses ubuntu-20.04 and it is a [composite](https://docs.github.com/en/actions/creating-actions/about-custom-actions).
+The Action uses ubuntu-20.04 and it is a [composite action](https://docs.github.com/en/actions/creating-actions/about-custom-actions).
 It internally downloads needed binaries `curl` and `jq` for communicating with the Testing Farms API and parsing the responses.
  
-API key to the Testing Farm should be stored in your organization's secrets to successfully access its infrastructure.
+API key to the Testing Farm MUST be stored in your organization's secrets to successfully access its infrastructure.
+See [Testing Farm onboarding guide](https://docs.testing-farm.io/general/0.1/onboarding.html) for information how to onboard to Testing Farm.
+
+## Compatibility Notes
+
+⚠ Currently only testing of copr builds is supported by the action.
+See [Testing Farm docs](https://docs.testing-farm.io) for more information on supported test artifacts which Testing Farm can install into the environment.
 
 ## Action Inputs
 
+### Testing Farm
+
 | Input Name                   | Description                                                                                                                       | Default value                 |
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| `api_key`                    | A testing farm API key.                                                                                                           | empty, **required from user** |
-| `tmt_repository`             | An url to tmt repository                                                                                                          | empty, **required from user** |
-| `test_fmf_plan`              | A fmf plan which will be selected from tmt repository.                                                                            | all                           |
-| `tests_tmt_ref`              | A tmt tests branch which will be used for tests                                                                                   | master                        |
+| `api_key`                    | Testing farm API key.                                                                                                             | empty, **required from user** |
+
+### Tmt Metadata
+
+| Input Name                   | Description                                                                                                                       | Default value                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `git_url`                    | An url to the repository with tmt metadata                                                                                        | empty, **required from user** |
+| `git_ref`                    | A tmt tests branch which will be used for tests                                                                                   | master                        |
+| `tmt_plan_regex`             | A regular expression used to select tmt plans.                                                                                    | all                           |
+| `tmt_context`                | A mapping of tmt context variable [tmt-context](https://tmt.readthedocs.io/en/latest/spec/context.html), variables separated by ; | empty                         |
+
+### Test Environment
+
+| Input Name                   | Description                                                                                                                       | Default value                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | `compose`                    | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes)                                     | Fedora                        |
+| `arch`                       | Define an architecture for testing environment                                                                                    | x86_64                        |
+| `variables`                  | Environment variables for test env, separated by ;                                                                                | empty                         |
+| `secrets`                    | Environment secrets for test env, separated by ;                                                                                  | empty                         |
+
+### Test Artifacts
+
+| `copr`                       | Copr name to use for the artifacts                                                                                                | epel-7-x86_64                 |
+| `copr_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
+
+### Miscellaneous
+
 | `create_issue_comment`       | If GitHub action will create a github issue comment.                                                                              | false                         |
 | `pull_request_status_name`   | GitHub pull request status name                                                                                                   | Fedora                        |
-| `arch`                       | Define an architecture for testing environment                                                                                    | x86_64                        |
-| `env_vars`                   | Environment variables for test env, separated by ;                                                                                | empty                         |
-| `env_secrets`                | Environment secrets for test env, separated by ;                                                                                  | empty                         |
-| `copr`                       | Copr name to use for the artifacts                                                                                                | epel-7-x86_64                 |
-| `test_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
 | `debug`                      | Print debug logs when working with testing farm                                                                                   | true                          |
 | `update_pull_request_status` | Action will update pull request status. Default: true                                                                             | true                          |
-| `tmt_context`                | A mapping of tmt context variable [tmt-context](https://tmt.readthedocs.io/en/latest/spec/context.html), variables separated by ; | empty                         |
 
 ## Example
 
@@ -65,14 +88,14 @@ jobs:
       - name: Checkout repo and switch to corresponding pull request
         uses: actions/checkout@v2
         with:
-          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+          git_ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
           
       - name: Schedule test on Testing Farm 
         uses: sclorg/testing-farm-as-github-action@v1
         with:
           api_key: ${{ secrets.TF_API_KEY }}
-          tmt_repository: https://github.com/sclorg/sclorg-testing-farm
-          test_fmf_plan: "centos"
+          git_url: https://github.com/sclorg/sclorg-testing-farm
+          tmt_plan_regex: "centos"
           pull_request_status_name: "CentOS 7"
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `copr_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
 
 ### Miscellaneous
-
+| Input Name                   | Description                                                                                                                       | Default value                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | `create_issue_comment`       | If GitHub action will create a github issue comment.                                                                              | false                         |
 | `pull_request_status_name`   | GitHub pull request status name                                                                                                   | Fedora                        |
 | `debug`                      | Print debug logs when working with testing farm                                                                                   | true                          |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `secrets`                    | Environment secrets for test env, separated by ;                                                                                  | empty                         |
 
 ### Test Artifacts
-
+| Input Name                   | Description                                                                                                                       | Default value                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | `copr`                       | Copr name to use for the artifacts                                                                                                | epel-7-x86_64                 |
 | `copr_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
 

--- a/action.yml
+++ b/action.yml
@@ -9,18 +9,18 @@ inputs:
   api_key:
     description: 'A testing farm API key'
     required: true
-  tmt_repository:
-    description: 'An url to tmt repository'
+  git_url:
+    description: 'An url to the GIT repository'
     required: true
-  test_fmf_plan:
-    required: false
-    description: 'A fmf plan which will be selected. By default all plans are selected.'
-  tests_tmt_ref:
+  git_ref:
     description: 'A tmt tests branch which will be used for tests'
     required: false
     default: 'master'
+  tmt_plan_regex:
+    required: false
+    description: 'A tmt plan regex which will be used for selecting plans. By default all plans are selected.'
   compose:
-    description: 'A compose for tests'
+    description: 'A compose to run tests against.'
     default: 'Fedora'
     required: true
   create_issue_comment:
@@ -31,12 +31,12 @@ inputs:
     description: 'GitHub pull request status name'
     required: false
     default: 'Fedora'
-  env_vars:
-    description: 'Environment variables for test env, separated by ;'
+  variables:
+    description: 'Environment variables for test, separated by ;'
     required: false
     default: ''
-  env_secrets:
-    description: 'Environment secrets for test env, separated by ;'
+  secrets:
+    description: 'Secret environment variables for test env, separated by ;'
     required: false
     default: ''
   debug:
@@ -55,7 +55,7 @@ inputs:
     description: 'Name of copr to use for the artifacts'
     required: false
     default: 'epel-7-x86_64'
-  test_artifacts:
+  copr_artifacts:
     description: '"fedora-copr-build" artifacts for testing environment. Separated by ;'
     required: false
     default: ''
@@ -91,26 +91,26 @@ runs:
     - name: Generate tmt variables
       id: generate_tmt_vars
       run: |
-        python -c 'import json; print({} if not "${{ inpust.env_vars }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inpust.env_vars }}".split(";")]}))' > env_vars
-        echo "::set-output name=TMT_ENV_VARS::$(cat env_vars)"
+        python -c 'import json; print({} if not "${{ inpust.variables }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inpust.variables }}".split(";")]}))' > variables
+        echo "::set-output name=TMT_ENV_VARS::$(cat variables)"
 
     - name: Generate tmt secrets
       id: generate_tmt_secrets
       run: |
-        python -c 'import json; print({} if not "${{ inpust.env_secrets }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inpust.env_secrets }}".split(";")]}))' > env_secrets
-        echo "::set-output name=TMT_ENV_SECRETS::$(cat env_secrets)"
+        python -c 'import json; print({} if not "${{ inpust.secrets }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inpust.secrets }}".split(";")]}))' > secrets
+        echo "::set-output name=TMT_ENV_SECRETS::$(cat secrets)"
 
     - name: Generate tmt artifacts
       id: generate_tmt_artifacts
       run: |
-        python -c 'import json;print(json.dumps(([{"type": "fedora-copr-build", "id": "{}:${{ inputs.copr }}".format(copr_id)} for copr_id in "${{ inputs.env_artifacts }}".split(";")])))' > artifacts
-        echo "::set-output name=TMT_ENV_ARTIFACTS::$(cat env_artifacts)"
+        python -c 'import json;print(json.dumps(([{"type": "fedora-copr-build", "id": "{}:${{ inputs.copr }}".format(copr_id)} for copr_id in "${{ inputs.copr_artifacts }}".split(";")])))' > artifacts
+        echo "::set-output name=TMT_ENV_ARTIFACTS::$(cat copr_artifacts)"
 
     - name: Generate tmt context
-      id: generate_tmt_context
+      id: generate_context
       run: |
-        python -c 'import json; print({} if not "${{ inputs.tmt_context }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inputs.tmt_context }}".split(";")]}))' > tmt_context
-        echo "::set-output name=TMT_CONTEXT::$(cat tmt_context)"
+        python -c 'import json; print({} if not "${{ inputs.tmt_context }}".strip() else json.dumps({key: value for key, value in [s.split("=", 1) for s in "${{ inputs.tmt_context }}".split(";")]}))' > context
+        echo "::set-output name=TMT_CONTEXT::$(cat context)"
 
     - name: Schedule a test on Testing Farm
       id: sched_test
@@ -119,9 +119,9 @@ runs:
         {
           "api_key": "${{ inputs.api_key }}",
           "test": { "fmf": {
-              "url": "${{ inputs.tmt_repository }}",
-              "ref": "${{ inputs.tmt_ref }}",
-              "name": "{{ inputs.tests_tmt_ref }}",
+              "url": "${{ inputs.git_url }}",
+              "ref": "${{ inputs.git_ref }}",
+              "name": "{{ inputs.tmt_plan_regex }}",
             }
           },
           "environments": [{
@@ -133,26 +133,26 @@ runs:
             "secrets": "${{ steps.generate_tmt_secrets.outputs.TMT_ENV_SECRETS }}",
             "artifacts: "${{ steps.generate_tmt_artifacts.outputs.TMT_ENV_ARTIFACTS }}",
             "tmt": {
-              "context": ${{ steps.generate_tmt_context.outputs.TMT_CONTEXT }}
+              "context": ${{ steps.generate_context.outputs.TMT_CONTEXT }}
             }
           }]
         }
         EOF
         if [ "${{ inputs.debug }}" == "true" ]; then
-          echo "Let's print request.json"
-          cat request.json
+          echo "Let's print request.json (except api_key and secrets)"
+          cat request.json | jq 'del(.api_key, .environments[].secrets)'
         fi
         curl https://api.testing-farm.io/requests \
             --data @request.json \
             --header "Content-Type: application/json" \
             --output response.json
-        
+
         if [ "${{ inputs.debug }}" == "true" ]; then
           echo "Let's print testing farm response"
           cat response.json
           jq < response.json
         fi
-        
+
         # Store REQ_ID into GITHUB_ENV variables
         req_id=$(jq -r .id response.json)
         tf_url=$(jq -r .run.artifacts response.json)
@@ -206,7 +206,7 @@ runs:
         if [ "${{ inputs.debug }}" == "true" ]; then
           cat job.json
           jq < job.json
-        fi          
+        fi
         state=$(jq -r .state job.json)
         result=$(jq -r .result.overall job.json)
         new_state="success"


### PR DESCRIPTION
After reviewing I would a bit streamline the options, I believe they can
be shorter and grouped into different settings groups.

Also we should hide secrets even in case of debug output, safety first
:)

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>