### PR TITLE
remove pr_nr step as it is not needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,13 +89,6 @@ runs:
         sudo apt update && sudo apt -y install curl jq
       shell: bash
 
-    - name: Get pull request number
-      id: pr_nr
-      run: |
-        PR_URL="${{ github.event.comment.issue_url }}"
-        echo "::set-output name=PR_NR::${PR_URL##*/}"
-      shell: bash
-
     - name: Get commit SHA value
       id: sha_value
       run: |


### PR DESCRIPTION
I think, that this step is needed for checkout the correct commit in the git repo, which must be done in action, which uses `testing-farm-as-github-action`, and not in `testing-farm-as-github-action` itself.