### PR TITLE
Make use of required github_token input, adjust README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 
 ### Testing Farm
 
-| Input Name                   | Description                                                                                                                       | Default value                 |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| `api_key`                    | Testing farm API key.                                                                                                             | empty, **required from user** |
+| Input Name | Description | Default value |
+|------------|-------------|---------------|
+| `api_key`  | Testing farm API key | empty, **required from user** |
+| `api_url`  | Testing farm server url | empty, **required from user** |
 
 ### Tmt Metadata
 
@@ -53,12 +54,13 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `copr_artifacts`             | `fedora-copr-build` artifacts for testing environment, separated by ;                                                             | empty                         |
 
 ### Miscellaneous
-| Input Name                   | Description                                                                                                                       | Default value                 |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| `create_issue_comment`       | If GitHub action will create a github issue comment.                                                                              | false                         |
-| `pull_request_status_name`   | GitHub pull request status name                                                                                                   | Fedora                        |
-| `debug`                      | Print debug logs when working with testing farm                                                                                   | true                          |
-| `update_pull_request_status` | Action will update pull request status. Default: true                                                                             | true                          |
+| Input Name | Description | Default value |
+|------------|-------------|---------------|
+| `github_token` | Github token passed from secrets | `${{ github.token }}` |
+| `create_issue_comment` | If GitHub action will create a github issue comment | false |
+| `pull_request_status_name` | GitHub pull request status name | Fedora |
+| `debug` | Print debug logs when working with testing farm | true |
+| `update_pull_request_status` | Action will update pull request status. Default: true | true |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,11 @@ inputs:
   git_ref:
     description: 'A tmt tests branch which will be used for tests'
     required: false
-    default: 'master'    
+    default: 'master'
   github_token:
     description: 'A github token passed from secrets'
-    required: true
+    required: false
+    default: ${{ github.token }}
   tmt_plan_regex:
     required: false
     description: 'A tmt plan regex which will be used for selecting plans. By default all plans are selected.'
@@ -199,7 +200,7 @@ runs:
         fi
         # Update GitHub status description to 'Build started'
         curl -X POST \
-          -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ steps.sha_value.outputs.SHA }} \
           --data @running.json > update.json
@@ -277,7 +278,7 @@ runs:
           cat final_request.json
         fi
         # Switch Github status to proper state
-        curl -X POST -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
+        curl -X POST -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ steps.sha_value.outputs.SHA }} \
           --data @final_request.json > final_response.json


### PR DESCRIPTION
I have noticed, that this commit: https://github.com/sclorg/testing-farm-as-github-action/commit/0ce2342f5ac88cf6413e53e32fa32c83339aeb4e adds to the action the `github_token` input, which is required.

This PR makes use of this input and adds info to the README.