### PR TITLE
Introduce environment_settings input

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `pull_request_status_name` | GitHub pull request status name | Fedora |
 | `debug` | Print debug logs when working with testing farm | true |
 | `update_pull_request_status` | Action will update pull request status. Default: true | true |
+| `environment_settings` | Pass custom settings to the test environment. Default: {} | empty |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
     description: 'Defines the scope of Testing Farm. Possible options are public and private'
     required: false
     default: 'public'
+  environment_settings:
+    description: 'Pass specific settings, like post-install-script, to the testing environment.'
+    required: false
+    default: '{}'
 outputs:
   request_id:
     description: 'An ID of a scheduled testing farm request'
@@ -152,6 +156,7 @@ runs:
               "compose": "${{ inputs.compose }}"
             },
             "variables": ${{ steps.generate_tmt_vars.outputs.TMT_ENV_VARS }},
+            "settings": ${{ inputs.environment_settings }},
             "secrets": ${{ steps.generate_tmt_secrets.outputs.TMT_ENV_SECRETS }},
             ${{ steps.generate_artifacts.outputs.TMT_ENV_ARTIFACTS }}
             "tmt": {


### PR DESCRIPTION
This will allow passing custom environment settings to the test env,
like specific post-install-scripts to be run during guest provisioning.

OAMG-6748