### PR TITLE
Add pr_head_sha input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ The tests to run are to be described with a [`tmt` plan](https://tmt.readthedocs
 Pull Request status is automatically updated after the tests are executed,
 if this option is enabled with the `update_pull_request_status` user-defined input variable.
 
-Before calling this GitHub Action, you must first clone your project,
-e.g., with the [Checkout V2](https://github.com/actions/checkout) GitHub Action.
-
 The Action uses ubuntu-20.04 and it is a [composite action](https://docs.github.com/en/actions/creating-actions/about-custom-actions).
 It internally downloads needed binaries `curl` and `jq` for communicating with the Testing Farms API and parsing the responses.
 
 API key to the Testing Farm MUST be stored in your organization's secrets to successfully access its infrastructure.
 See [Testing Farm onboarding guide](https://docs.testing-farm.io/general/0.1/onboarding.html) for information how to onboard to Testing Farm.
+
+Setting `update_pull_request_status` input to `true` requires information of Pull Request's HEAD SHA value.
+Therefore before calling this GitHub Action, the GitHub repo must be firt cloned and checkouted on the Pull Request, in order to obtain the correct SHA value of Pull Requests's HEAD commit.
+Alternatively, the HEAD SHA of the Pull Request can be provided as a `pr_head_sha` input.
+
 
 ## Compatibility Notes
 
@@ -63,6 +65,7 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `debug` | Print debug logs when working with testing farm | true |
 | `update_pull_request_status` | Action will update pull request status. Default: true | true |
 | `environment_settings` | Pass custom settings to the test environment. Default: {} | empty |
+| `pr_head_sha` | SHA of the latest commit in PR. Used for communication with GitHub API. | $(git rev-parse HEAD) |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ API key to the Testing Farm MUST be stored in your organization's secrets to suc
 See [Testing Farm onboarding guide](https://docs.testing-farm.io/general/0.1/onboarding.html) for information how to onboard to Testing Farm.
 
 Setting `update_pull_request_status` input to `true` requires information of Pull Request's HEAD SHA value.
-Therefore before calling this GitHub Action, the GitHub repo must be firt cloned and checkouted on the Pull Request, in order to obtain the correct SHA value of Pull Requests's HEAD commit.
+Therefore before calling this GitHub Action, the GitHub repo must be first cloned and checked out on the Pull Request, in order to obtain the correct SHA value of Pull Request's HEAD commit.
 Alternatively, the HEAD SHA of the Pull Request can be provided as a `pr_head_sha` input.
 
 

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: 'Pass specific settings, like post-install-script, to the testing environment.'
     required: false
     default: '{}'
+  pr_head_sha:
+    required: false
+    default: ''
+
 outputs:
   request_id:
     description: 'An ID of a scheduled testing farm request'
@@ -96,12 +100,17 @@ runs:
 
     - name: Get commit SHA value
       id: sha_value
+      if: ${{ inputs.update_pull_request_status == 'true' }}
       run: |
-        _sha=$(git rev-parse HEAD)
-        if [ -z $_sha ]; then
-          echo "Failed to obtain SHA of current commit. Halting"
-          echo "Make sure, that current directory is a git repository"
-          exit 1
+        _sha="${{ inputs.pr_head_sha }}"
+        if [[ -z $_sha ]]; then
+          _sha=$(git rev-parse HEAD)
+          if [[ -z $_sha ]]; then
+            echo "Failed to obtain SHA of current commit. Halting."
+            echo "Make sure, that current directory is a git repository"
+            echo "or provide the PR's HEAD SHA as input."
+            exit 1
+          fi
         fi
         echo "::set-output name=SHA::$_sha"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
       if: ${{ inputs.update_pull_request_status == 'true' }}
       run: |
         _sha="${{ inputs.pr_head_sha }}"
-        if [[ -z $_sha ]]; then
+        if [[ -z "$_sha" ]]; then
           _sha=$(git rev-parse HEAD)
           if [[ -z $_sha ]]; then
             echo "Failed to obtain SHA of current commit. Halting."

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
         _sha="${{ inputs.pr_head_sha }}"
         if [[ -z "$_sha" ]]; then
           _sha=$(git rev-parse HEAD)
-          if [[ -z $_sha ]]; then
+          if [[ -z "$_sha" ]]; then
             echo "Failed to obtain SHA of current commit. Halting."
             echo "Make sure, that current directory is a git repository"
             echo "or provide the PR's HEAD SHA as input."

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,13 @@ runs:
     - name: Get commit SHA value
       id: sha_value
       run: |
-        echo "::set-output name=SHA::$(git rev-parse HEAD)"
+        _sha=$(git rev-parse HEAD)
+        if [ -z $_sha ]; then
+          echo "Failed to obtain SHA of current commit. Halting"
+          echo "Make sure, that current directory is a git repository"
+          exit 1
+        fi
+        echo "::set-output name=SHA::$_sha"
       shell: bash
 
     - name: Set artifacts url


### PR DESCRIPTION
This PR adds possibility for the user to define PR HEAD SHA.
When using this input it is no longer needed to clone repo and checkout the PR before calling the `testing-farm-as-a-github-action`, when user wants updates to the PR status.

If the SHA is not provided, it is obtained same as before, with $(git rev-parse HEAD). If this fails the action is halted.

SHA obtaining is enabled only when the `update_pull_request_status` input is enabled.


resolves https://github.com/sclorg/testing-farm-as-github-action/issues/50