### PR TITLE
Generate tmt_context by generate_tmt_vars.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tests/copr_artifacts
 tests/secrets
 tests/variables
+tests/tmt_context

--- a/generate_tmt_vars.py
+++ b/generate_tmt_vars.py
@@ -34,7 +34,7 @@ json_dict: Dict = {}
 output_name = ""
 if len(sys.argv) == 2:
     output_name = sys.argv[1]
-    if output_name != "variables" and output_name != "secrets":
+    if output_name != "variables" and output_name != "secrets" and output_name != "tmt_context":
         sys.exit(1)
 
 if len(sys.argv) > 2:

--- a/tests/test_tmt.py
+++ b/tests/test_tmt.py
@@ -53,9 +53,31 @@ def test_tmt_variables_missing_second_parameter():
     assert json_string == expected
 
 
+def test_tmt_context_missing_second_parameter():
+    expected = {}
+    output_name = "tmt_context"
+    ret_val = subprocess.call(f"python3 {TESTDIR}/../generate_tmt_vars.py \"{output_name}\"", shell=True)
+    assert ret_val == 0
+    with open(output_name, "r") as f:
+        data = f.read()
+    json_string = json.loads(data)
+    assert json_string == expected
+
+
 def test_tmt_variables_one_parameter():
     expected = {"data": "123"}
     output_name = "variables"
+    ret_val = subprocess.call(f"python3 {TESTDIR}/../generate_tmt_vars.py \"{output_name}\" \"data=123\"", shell=True)
+    assert ret_val == 0
+    with open(output_name, "r") as f:
+        data = f.read()
+    json_string = json.loads(data)
+    assert json_string == expected
+
+
+def test_tmt_context_one_parameter():
+    expected = {"data": "123"}
+    output_name = "tmt_context"
     ret_val = subprocess.call(f"python3 {TESTDIR}/../generate_tmt_vars.py \"{output_name}\" \"data=123\"", shell=True)
     assert ret_val == 0
     with open(output_name, "r") as f:


### PR DESCRIPTION
This pull request generates tmt_context by generate_tmt_vars.py
This is only pre-migration step.

Every variable will be generated by python scripts introduced by PR https://github.com/sclorg/testing-farm-as-github-action/pull/48
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>