### PR TITLE
Use GitHub action to update release tags (`v1`, `v2`, ...) and `latest`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,33 +1,27 @@
-# Source: https://github.com/release-drafter/release-drafter/blob/master/.github/workflows/release.yml
 ---
 
-name: Release
+name: GitHub Tag Update
+
 on:
-  push:
-    tags:
-      - v*.*.*
+  release:
+    types: [ published, edited ]
+
+permissions:
+  contents: read
 
 jobs:
-  release:
+  tag-update:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Repository checkout
+        uses: actions/checkout@v3
+
+      - name: Update tag
+        uses: Actions-R-Us/actions-tagger@v2
         with:
-          fetch-depth: 0
-
-      - name: Version
-        id: version
-        run: |
-          tag=${GITHUB_REF/refs\/tags\//}
-          version=${tag#v}
-          major=${version%%.*}
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=version::${version}"
-          echo "::set-output name=major::${major}"
-
-      - name: force update major tag
-        run: |
-          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
-          git push origin refs/tags/v${{ steps.version.outputs.major }} -f
+          publish_latest_tag: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[`Actions-R-Us/actions-tagger`](https://github.com/Actions-R-Us/actions-tagger#readme) takes care of your major (`v1`, `v2`, ...) release tags, as well as the `latest` release tag.

After the next release, you will be able to use the following:

```yml
uses: sclorg/testing-farm-as-github-action@latest
```