### PR TITLE
Add one line for ranches. Add TMT example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -55,12 +55,6 @@ prepare:
       script: |
         # install packages on guest system
 
-    - name: Install packages on machine by ansible
-      how: ansible
-      playbook:
-        - ansible-plan.yml
-      extra-args: -vv
-
     - name: Clone repo and switch to the PR
       how: shell
       script: |

--- a/USAGE.md
+++ b/USAGE.md
@@ -87,8 +87,8 @@ Create a directory `.github/workflows` in your GitHub repository.
 ### Testing pull request changes via Testing Farm
 
 Create a file like `testing-farm-pr.yml`
-The file can look like as is mentioned in [README.md](https://github.com/sclorg/testing-farm-as-github-action#example)
+The file can look like as is mentioned in [README.md](https://github.com/sclorg/testing-farm-as-github-action#pull-request-example)
 
 ### Testing or other actions performed at push to the main branch.
 Create a file like `testing-farm-merge.yml`
-The file can look like as is mentioned in [README.md](https://github.com/sclorg/testing-farm-as-github-action#example)
+The file can look like as is mentioned in [README.md](https://github.com/sclorg/testing-farm-as-github-action#run-workflow-at-push-to-the-main-branch)

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,7 @@ there are several steps which you have to do it.
 ## Ask Testing Farm team for public or private ranch
 
 Before any implementation as Testing Farm team for API_KEY here [onboarding](https://docs.testing-farm.io/general/0.1/onboarding.html).
+
 Public ranch is used for testing your upstream repository on Fedora, CentOS 7, and CentOS Stream guests.
 
 Private ranch is used for testing your upstream repository on RHEL and Oracle-linux guests.
@@ -31,6 +32,50 @@ How to test your TMT plans locally? Run a command:
 ```bash
 $ tmt run plan --name <your TMT plan name>
 ```
+
+### Example TMT plan
+How can TMT plan can look like?
+
+```yaml
+summary: TMT/TFT plan for tests on your host
+description: |
+    Run tests on host
+
+discover:
+    how: shell
+    tests:
+    - name: Run your tests on specific host
+      framework: shell
+      test: <run your test suite in a specific directory>
+      duration: 3h
+
+prepare:
+    - name: Install important packages for your tests
+      how: shell
+      script: |
+        # install packages on guest system
+
+    - name: Install packages on machine by ansible
+      how: ansible
+      playbook:
+        - ansible-plan.yml
+      extra-args: -vv
+
+    - name: Clone repo and switch to the PR
+      how: shell
+      script: |
+        # Testing Farm does not know where the repo is, so first clone it
+        git clone $REPO_URL /tmp/$REPO_NAME
+        cd /tmp/$REPO_NAME
+        git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
+        git checkout origin/pr/$PR_NUMBER/head
+        git submodule update --init
+
+execute:
+    how: tmt
+```
+
+
 ## Setup GitHub Action
 
 As soon as you have your TMT plan ready then let's create an GitHub Actions for your use case


### PR DESCRIPTION
This commit adds one line to a better reading option for ranches.

Adds also TMT examples and fixes the links to README.md
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>