### PR TITLE
Let's use setup-python@v4 and version '3.6.15' instead of "3.6.15"

### DIFF
--- a/.github/workflows/test_python_scripts.yml
+++ b/.github/workflows/test_python_scripts.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.6.15"
+        python-version: '3.6.15'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
See docu here: https://github.com/actions/setup-python#basic-usage

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>