### PR TITLE
add test for github summary

### DIFF
--- a/.github/workflows/github_summary_test.yml
+++ b/.github/workflows/github_summary_test.yml
@@ -1,0 +1,29 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  container-tests:
+    runs-on: ubuntu-22.04
+    name: "GitHub summary test for testing farm as a github action"
+
+    if: |
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '[test]')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
+      - name: Run the tests
+        uses: ./
+        with:
+          api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          git_url: "https://github.com/sclorg/testing-farm-as-github-action"
+          git_ref: "main"
+          tmt_plan_regex: "smoke_plan"
+          pull_request_status_name: "Smoke test"
+          create_github_summary: "true"


### PR DESCRIPTION
test enables github_summary input in TFaGA workflow, so that the developer can check if the summary is correctly displayed.

This test is based on the smoke test.