### PR TITLE
print GitHub summary if enabled with input

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 
 | Input Name | Description | Default value |
 |------------|-------------|---------------|
-| `compose` | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes) | Fedora |
+| `compose` | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes) | Fedora-latest |
 | `arch` | Define an architecture for testing environment | x86_64 |
 | `variables` | Environment variables for test env, separated by ; | empty |
 | `secrets` | Environment secrets for test env, separated by ; | empty |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [Testing Farm docs](https://docs.testing-farm.io) for more information on su
 | `update_pull_request_status` | Action will update pull request status. Default: true | true |
 | `environment_settings` | Pass custom settings to the test environment. Default: {} | empty |
 | `pr_head_sha` | SHA of the latest commit in PR. Used for communication with GitHub API. | $(git rev-parse HEAD) |
+| `create_github_summary` | Create summary of the Testing Farm as GiHub Action job. Possible options: "false", "true", "key=value" | true |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Action will update pull request status. Default: true'
     required: false
     default: 'true'
+  create_github_summary:
+    description: 'Action will create github summary. Possible options: "false", "true", "key=value"'
+    required: false
+    default: 'true'
   arch:
     description: 'Define an architecture for testing environment. Default: x86_64'
     required: false
@@ -328,6 +332,34 @@ runs:
                   '[here](${{ steps.artifacts_url.outputs.url }}/${{ steps.sched_test.outputs.req_id }}/).' +
                   '\n[Full pipeline log](${{ steps.artifacts_url.outputs.url }}/${{ steps.sched_test.outputs.req_id }}/pipeline.log).'
           })
+
+    - name: Create github summary
+      if: ${{ inputs.create_github_summary != 'false' }}
+      shell: bash
+      run: |
+        if [ -z "${{ steps.final_state.outputs.INFRA_STATE }}" ]; then
+          infra_state=OK
+        else
+          infra_state=Failed
+        fi
+        user_summary="${{ inputs.create_github_summary }}"
+        if [ "$user_summary" != 'true' ]; then
+          # In this case we expect key=value string inside
+          # 'create_github_summary' input.
+          # We obtain from it a table column and insert it to the GITHUB_STEP_SUMMARY.
+          user_key="${user_summary%%=*}|"
+          user_value="${user_summary##*=}|"
+          user_line="--|"
+        fi
+        tfaga_summary_header="Testing Farm as a GitHub Action summary:"
+        if  ! cat "$GITHUB_STEP_SUMMARY" | grep "$tfaga_summary_header" > /dev/null; then
+          echo "$tfaga_summary_header" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Compose | Arch | $user_key Infrastructure State | Test result | Link to logs |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|------| $user_line ----------------------|-------------|--------------|" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        echo "|${{ inputs.compose }}|${{ inputs.arch }}| $user_value $infra_state |"\
+             " ${{ steps.final_state.outputs.FINAL_STATE }}|"\
+             "${{ steps.artifacts_url.outputs.url }}/${{ steps.sched_test.outputs.req_id }}|" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Exit with error in case of failure in test
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -267,7 +267,7 @@ runs:
         state=$(jq -r .state job.json)
         result=$(jq -r .result.overall job.json)
         new_state="success"
-        infra_error=" "
+        infra_error=""
         log=""
         echo "State is $state and result is: $result"
         if [ "$state" == "complete" ]; then
@@ -276,7 +276,7 @@ runs:
           fi
         else
           # Mark job in case of infrastructure issues. Report to Testing Farm team
-          infra_error=" - Infra problems"
+          infra_error="- Infra problems"
           new_state="failure"
           log="pipeline.log"
         fi
@@ -295,7 +295,7 @@ runs:
           "sha": "${{ steps.sha_value.outputs.SHA }}",
           "state": "${{ steps.final_state.outputs.FINAL_STATE }}",
           "context": "Testing Farm - ${{ inputs.pull_request_status_name }}",
-          "description": "Build finished${{ steps.final_state.outputs.INFRA_STATE }}",
+          "description": "Build finished ${{ steps.final_state.outputs.INFRA_STATE }}",
           "target_url": "${{ steps.artifacts_url.outputs.url }}/${{ steps.sched_test.outputs.req_id }}/${{ steps.final_state.outputs.LOG }}"
         }
         EOF


### PR DESCRIPTION
In the GitHub Actions tab a summary of ran job would be displayed if
enabled in inputs. Compose, arch, infra state and test results are
available.