### PR TITLE
Improve logging by using `::error::`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,9 +111,7 @@ runs:
         if [[ -z "$_sha" ]]; then
           _sha=$(git rev-parse HEAD)
           if [[ -z "$_sha" ]]; then
-            echo "Failed to obtain SHA of current commit. Halting."
-            echo "Make sure, that current directory is a git repository"
-            echo "or provide the PR's HEAD SHA as input."
+            echo "::error::Failed to obtain SHA of current commit. Halting. Make sure, that current directory is a git repository or provide the PR's HEAD SHA as input."
             exit 1
           fi
         fi


### PR DESCRIPTION
[`::error::`](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) Will create annotations on the workflow summary page. It's more visible than just logging into the console.