### PR TITLE
Poll for job status even for non-PR usecases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -237,7 +237,6 @@ runs:
 
     - name: Check if scheduled test is still running
       id: still_running
-      if: ${{ inputs.update_pull_request_status == 'true' }}
       run: |
         CMD=${{ inputs.api_url }}/requests/${{ steps.sched_test.outputs.req_id }}
         curl $CMD > job.json
@@ -259,7 +258,6 @@ runs:
 
     - name: Get final state of Testing Farm scheduled request
       id: final_state
-      if: ${{ inputs.update_pull_request_status == 'true' }}
       run: |
         curl ${{ inputs.api_url }}/requests/${{ steps.sched_test.outputs.req_id }} > job.json
         if [ "${{ inputs.debug }}" == "true" ]; then


### PR DESCRIPTION
It is important also for non-PR jobs to see progress of TF in executing the testing job so that the INFRA state can be parsed from TF's output and job result can be set as final result of the GitHub Action job.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
