### PR TITLE
Remove `typescript` branch from workflows

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - typescript
     paths-ignore:
       - '**.md'
   pull_request:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, typescript ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, typescript ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Linting suite
 
 on:
   push:
-    branches: [ main, typescript ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, typescript ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Unit and Integration tests
 
 on:
   push:
-    branches: [ main, typescript ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, typescript ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
It's no longer needed. Development is now happening in the `main` branch.