### PR TITLE
update concurrency part in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ on:
 
 # The concurrency key is used to prevent multiple workflows from running at the same time
 concurrency:
-  group: ${{ github.head_ref }}
+  group: my-concurrency-group
   cancel-in-progress: true
 
 jobs:
@@ -111,7 +111,7 @@ jobs:
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
       - name: Schedule test on Testing Farm
-        uses: sclorg/testing-farm-as-github-action@v1
+        uses: sclorg/testing-farm-as-github-action@v2
         with:
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: https://github.com/sclorg/sclorg-testing-farm

--- a/README.md
+++ b/README.md
@@ -144,10 +144,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Schedule test on Testing Farm
-        uses: sclorg/testing-farm-as-github-action@v1
+        uses: sclorg/testing-farm-as-github-action@v2
         with:
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: https://github.com/sclorg/sclorg-testing-farm
-          tmt_plan_regex: "centos"
-          update_pull_request_status: "false"
 ```


### PR DESCRIPTION
${{ github.head_ref }} is not available for issue_comment target, use simple string as an exemplary concurrency group. Use tfaga@v2 for this, as this is the first version supporting concurrency mechanisms.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
