### PR TITLE
Fix timeout test :timer_clock: 

### DIFF
--- a/.github/workflows/timeout-test.yml
+++ b/.github/workflows/timeout-test.yml
@@ -27,13 +27,25 @@ jobs:
           tmt_plan_regex: "timeout_plan"
           pull_request_status_name: "Timeout test"
           update_pull_request_status: "true"
-          timeout: 10
+          timeout: 60
 
-      - name: Check if log contains exceed limit
+      - name: Check if testing farm test reached past the timeout limit
+        if: ${{ !cancelled() }}
         run: |
           curl ${{ steps.tf_results.outputs.test_log_url }} > results.log
-          ret_val = $(grep 'duration \"10s\" exceeded' results.log)
-          if [[ $ret_val != 0 ]]; then
+          ret_val=$(grep "This should never happened because of timeout set on GHA" results.log)
+          if [[ $ret_val == 0 ]]; then
+            echo "Timeout parameter isn't working as expected"
             exit 1
           fi
-          exit 0
+
+      - name: Check if timeout was reached
+        if: ${{ !cancelled() }}
+        run: |
+          if [[ ${{ steps.tf_results.conclusion }} == 'success' ]]; then
+            echo "Action passed, timeout wasn't reached"
+            exit 1
+          fi
+          echo "Action failed, timeout was reached"
+
+

--- a/plans/timeout_plan.fmf
+++ b/plans/timeout_plan.fmf
@@ -1,10 +1,10 @@
 summary: Basic timeout test
 execute:
     how: tmt
-    duration: 10s
+    duration: 150m
     script: |
         set +x
-        echo "Set sleep time to an hour for sure."
-        sleep 30
-        echo "this should never happened because of timeout"
+        echo "Set sleep time to 300s (more then timeout set on GHA)"
+        sleep 300
+        echo "This should never happened because of timeout set on GHA"
         exit 0


### PR DESCRIPTION
follow-up to #181 

The original implementation of the test doesn't work as expected:

https://github.com/sclorg/testing-farm-as-github-action/actions/runs/9462296603/job/26064932008

