### PR TITLE
doc: fix and update `create_github_summary` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [Testing Farm onboarding guide](https://docs.testing-farm.io/Testing%20Farm/
 | `update_pull_request_status` | Action will update pull request status. | false |
 | `environment_settings` | Pass custom settings to the test environment. | empty |
 | `pipeline_settings` | Pass specific settings for the testing farm pipeline. For example, `'{ "type": "tmt-multihost" }'`. For details, see `settings.pipeline` field in [Request new test](https://api.testing-farm.io/redoc#operation/request_a_new_test_v0_1_requests_post). | empty |
-| `create_github_summary` | Create summary of the Testing Farm as GiHub Action job. Possible options: "false", "true", "key=value" | true |
+| `create_github_summary` | Create GitHub Job Summary accessible from Workflow run Summary. Possible options: "true" or "false" | true |
 | `timeout` | Timeout for the Testing Farm job in minutes. | 480 |
 
 ## Action Outputs

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     required: false
     default: 'false'
   create_github_summary:
-    description: 'Action will create github summary. Possible options: "false", "true", "key=value"'
+    description: 'Create GitHub Job Summary accessible from Workflow run Summary.. Possible options: "true" or "false"'
     required: false
     default: 'true'
   arch:


### PR DESCRIPTION
`key=value` is unsupported since `v2`