### PR TITLE
action.yml: remove incorrect comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ inputs:
     required: false
     default: 'Fedora'
   update_pull_request_status:
-    description: 'Action will update pull request status. Default: true'
+    description: 'Action will update pull request status.'
     required: false
     default: 'false'
   environment_settings:


### PR DESCRIPTION
Hi, long time no see :wave:. I just found a discrepancy in a input description.

<!-- testing-farm = {"lock":"false","comment-id":"2812784380","data":[{"id":"0d35b772-988c-4a88-b37e-fa4a8c8c3cfe","name":"Smoke test - pull_request_target","runTime":217.370772,"created":"2025-04-17T12:54:53.225892","updated":"2025-04-17T12:54:53.225901","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/0d35b772-988c-4a88-b37e-fa4a8c8c3cfe\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0d35b772-988c-4a88-b37e-fa4a8c8c3cfe/pipeline.log\">pipeline</a>"]}]} -->