### PR TITLE
Use "omit" instead of "null" to skip compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [Testing Farm onboarding guide](https://docs.testing-farm.io/Testing%20Farm/
 
 | Input Name | Description | Default value |
 |------------|-------------|---------------|
-| `compose` | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes) Use `null` to skip compose specification - needed for container provisioner with image specified in plan. | Fedora-latest |
+| `compose` | Compose to run tests on. [Available composes.](https://api.dev.testing-farm.io/v0.1/composes) Use the `omit` string to completely exclude the compose parameter from the request (needed for container provisioner with image specified in plan). | Fedora-latest |
 | `arch` | Define an architecture for testing environment | x86_64 |
 | `variables` | Environment variables for test env, separated by ; | empty |
 | `secrets` | Environment secrets for test env, separated by ; | empty |
@@ -165,9 +165,9 @@ jobs:
           api_key: ${{ secrets.TF_API_KEY }}
 ```
 
-### Using compose: null
+### Using compose: omit
 
-When you want to run tests without specifying a specific compose, you can use `compose: null`. This will skip the `os` field in the API request entirely. This is needed if you want to run testing against the container provisioner with the image specified in the plan. Specifying the container image via the API is not supported.
+When you want to run tests without specifying a specific compose, you can use `compose: omit`. It will exclude the `os` field from the API request entirely. This is needed if you want to run testing against the container provisioner with the image specified in the plan. Specifying the container image via the API is not supported.
 
 ```yaml
 name: Test with container provisioner
@@ -184,7 +184,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v4
         with:
           api_key: ${{ secrets.TF_API_KEY }}
-          compose: null
+          compose: omit
 ```
 
 ### How to setup Pull Request summary comments

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
 
   # Test Environment
   compose:
-    description: 'A compose to run tests against. Use "null" to skip compose specification - needed for container provisioner with image specified in plan.'
+    description: 'A compose to run tests against. Use "omit" to completely exclude the compose parameter from the request (needed for container provisioner with image specified in plan).'
     default: 'Fedora-latest'
     required: false
   arch:

--- a/src/action.ts
+++ b/src/action.ts
@@ -137,13 +137,12 @@ async function action(pr: PullRequest): Promise<void> {
     },
   };
 
-  // Always include os field, but set to null if compose input is empty/null
-  if (composeInput) {
+  // Include os field only if compose input is provided and not 'omit'
+  // If 'omit', the os field will be completely excluded from the request
+  if (composeInput && composeInput.toLowerCase() !== 'omit') {
     environment.os = {
       compose: composeInput,
     };
-  } else {
-    environment.os = null;
   }
 
   const request = {
@@ -271,7 +270,7 @@ async function action(pr: PullRequest): Promise<void> {
     runTime: tfResult.run_time || 0,
     created: tfResponse.created,
     updated: tfResponse.updated,
-    compose: composeInput || null,
+    compose: composeInput && composeInput.toLowerCase() !== 'omit' ? composeInput : null,
     arch: getInput('arch'),
     infrastructureFailure: infraError,
     status: state,

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -1374,7 +1374,7 @@ describe('Integration tests - action.ts', () => {
     expect(mocks.TFError).not.toHaveBeenCalled();
   });
 
-  test('Compose null test', async () => {
+  test('Compose omit test', async () => {
     setDefaultInputs();
 
     // Mock required Action inputs
@@ -1389,8 +1389,8 @@ describe('Integration tests - action.ts', () => {
     vi.stubEnv('INPUT_TMT_PLAN_REGEX', 'fedora');
 
     // Override default inputs
-    // compose - Set to empty string to simulate null/undefined input
-    vi.stubEnv('INPUT_COMPOSE', '');
+    // compose - Set to 'omit' to exclude the os field from the request
+    vi.stubEnv('INPUT_COMPOSE', 'omit');
 
     // mock the pull request number and sha in the context
     vi.stubEnv('INPUT_PR_NUMBER', '1');
@@ -1464,7 +1464,6 @@ describe('Integration tests - action.ts', () => {
       expect.objectContaining({
         environments: [
           expect.objectContaining({
-            os: null, // os should be null
             arch: process.env['INPUT_ARCH'], // arch should be set
           }),
         ],
@@ -1475,8 +1474,8 @@ describe('Integration tests - action.ts', () => {
     // Check if we have waited for Testing Farm to finish
     expect(mocks.requestDetails).toHaveBeenCalledTimes(5);
 
-    // Test that the request contains the 'os' field set to null
-    expect(capturedRequest.environments[0]).toHaveProperty('os', null);
+    // Test that the request does not contain the 'os' field when compose is 'omit'
+    expect(capturedRequest.environments[0]).not.toHaveProperty('os');
     expect(capturedRequest.environments[0]).toHaveProperty('arch');
 
     // Test outputs
@@ -1491,7 +1490,7 @@ describe('Integration tests - action.ts', () => {
     // All data are provided via context and statuses are disabled by default, no need to call GitHub API
     expect(mocks.request).toHaveBeenCalledTimes(0);
 
-    // Test summary - compose should show placeholder when null
+    // Test summary - compose should show placeholder when omit
     await assertSummary(`<h1>Testing Farm as a GitHub Action summary</h1>
 <table><tr><th>name</th><th>compose</th><th>arch</th><th>status</th><th>started (UTC)</th><th>time</th><th>logs</th></tr><tr><td>Fedora</td><td>&lt;container image from plan&gt;</td><td>${process.env['INPUT_ARCH']}</td><td>✅ passed</td><td>24.08.2021 14:15:22</td><td>1h 1min 31s</td><td><a href="https://artifacts.dev.testing-farm.io/1">test</a>  <a href="https://artifacts.dev.testing-farm.io/1/pipeline.log">pipeline</a></td></tr></table>
 `);


### PR DESCRIPTION
Using null doesn't work because

Using null as suggested by current readme fails with the following error. An example run is here: https://github.com/redhat-cop/infra.leapp/actions/runs/19141825777

```
Run sclorg/testing-farm-as-github-action@v4
Error: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "null",
    "path": [
      "environments",
      0,
      "os"
    ],
    "message": "Expected object, received null"
  }
]
```

I've tested my edits in https://github.com/spetrosi/infra.leapp/actions/runs/19170275013/job/54800766505

These changes are generated by Cursor AI

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
